### PR TITLE
Scroll to main items would be more better in user experience

### DIFF
--- a/frontend/components/Pagination.vue
+++ b/frontend/components/Pagination.vue
@@ -77,7 +77,7 @@
 </template>
 
 <script lang="ts" setup>
-import { useScrollToTop } from '@/composables/useScrollToTop'
+import { useScrollToMain } from '@/composables/useScrollToMain'
 
 const props = defineProps({
   total: {
@@ -92,7 +92,7 @@ const props = defineProps({
 
 const emit = defineEmits<{ (e: 'change', number): void }>()
 
-const { scrollToTop } = useScrollToTop()
+const { scrollToMain } = useScrollToMain()
 
 const STEP = 5
 
@@ -118,7 +118,7 @@ const pageRange = computed(() => {
 const handleChangePage = (item) => {
   activePage.value = item
   emit('change', activePage.value)
-  scrollToTop()
+  scrollToMain()
 }
 
 const handleNext = () => {

--- a/frontend/composables/useScrollToMain.ts
+++ b/frontend/composables/useScrollToMain.ts
@@ -1,0 +1,16 @@
+const useScrollToMain = () => {
+  const scrollToMain = () => {
+
+    const nodes = document.getElementsByTagName('main');
+    if (nodes && nodes[0]) {
+        const main = nodes[0];
+        main.scrollIntoView({ behavior: 'smooth'});
+    }
+  }
+
+  return {
+    scrollToMain
+  }
+}
+
+export { useScrollToMain }


### PR DESCRIPTION
Hi, thanks for creating this wonderful project!

I think scroll to main view is more convenient when user clicked another page or category.

Here just a little recommended for user experience after I used. 
I didn't test my code since I didn't know how to run your project in local. If my suggestion is good to you,  you may need to test before merged, thanks!

Below is a demo

![scroll](https://user-images.githubusercontent.com/32745146/193158964-c80241c6-296e-496e-bfaa-634a74a54f15.gif)